### PR TITLE
server/boot/gorm_mysql.go: 取消Initialize内GetByLink解析

### DIFF
--- a/server/boot/gorm.go
+++ b/server/boot/gorm.go
@@ -11,6 +11,7 @@ type _gorm struct{}
 func (g *_gorm) Initialize() {
 	switch global.Config.System.DbType {
 	case "mysql":
+		global.Config.Mysql = global.Config.Mysql.GetByLink()
 		Mysql.Initialize()
 	}
 }

--- a/server/boot/gorm_mysql.go
+++ b/server/boot/gorm_mysql.go
@@ -39,7 +39,7 @@ type _mysql struct {
 //@author: [SliverHorn](https://github.com/SliverHorn)
 //@description: gorm连接mysql数据库
 func (m *_mysql) Initialize() {
-	global.Config.Mysql = global.Config.Mysql.GetByLink()
+	//global.Config.Mysql = global.Config.Mysql.GetByLink()
 	if m.db, m.err = gorm.Open(mysql.New(mysql.Config{
 		DSN:                       global.Config.Mysql.Dsn(), // DSN data source name
 		DefaultStringSize:         191,                       // string 类型字段的默认长度

--- a/server/library/config/gorm.go
+++ b/server/library/config/gorm.go
@@ -36,7 +36,7 @@ func (m *Mysql) GetMaxOpenConnes() int {
 func (m *Mysql) GetByLink() Mysql {
 	var result Mysql
 	// link = "mysql:root:gdkid,,..@tcp(127.0.0.1:13307)/gf_vue_admin
-	link := g.Cfg().GetString("database.default.link")
+	link := g.Cfg().GetString("database.default.link")  //*这个地方GF的配置模块会默认找到config.yaml配置文件
 	// a := []string{"mysql", "root", "gdkid,,..@tcp(127.0.0.1", "13307)/gf_vue_admin"}
 	// a[0] = "mysql"
 	// a[1] = "root


### PR DESCRIPTION
Fix Bug:
    Hi, 这里发现在initdb的时候CheckDatabase方法在发现配置文件中的数据库不存在的时候，会试图通过database方法创建数据库。创建数据库前需要尝试连接数据库使用了Initialize方法，连接数据库需要指定db名，database方法中指定了db名"mysql"给Initialize内的GetByLink覆盖了。
   解决办法是将GetByLink的解析放在Initialize方法外。